### PR TITLE
fix: 修复 MembersManagement 组件缺少 onClearMessages 属性定义

### DIFF
--- a/src/pages/chat/components/MembersManagement.tsx
+++ b/src/pages/chat/components/MembersManagement.tsx
@@ -22,6 +22,7 @@ interface MembersManagementProps {
   getAvatarData: (name: string) => { backgroundColor: string; text: string };
   isGroupDiscussionMode: boolean;
   onToggleGroupDiscussion: () => void;
+  onClearMessages?: () => void;
 }
 
 export const MembersManagement = ({
@@ -32,7 +33,8 @@ export const MembersManagement = ({
   handleToggleMute,
   getAvatarData,
   isGroupDiscussionMode,
-  onToggleGroupDiscussion
+  onToggleGroupDiscussion,
+  onClearMessages
 }: MembersManagementProps) => {
   return (
     <Sheet open={showMembers} onOpenChange={setShowMembers}>


### PR DESCRIPTION
问题原因：
- MembersManagementProps 接口中缺少 onClearMessages 的类型定义
- 组件参数解构中也没有包含 onClearMessages
- 导致生产环境构建时属性未定义错误

解决方案：
1. 在 MembersManagementProps 接口中添加 onClearMessages?: () => void
2. 在组件参数解构中添加 onClearMessages
3. 确保类型定义完整且一致

这是导致 'onClearMessages is not defined' 错误的根本原因